### PR TITLE
Allow library to be used with bindbc-loader 1.1

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
     ],
     
     "dependencies": {
-        "bindbc-loader": "~>1.0.0"
+        "bindbc-loader": "~>1.0"
     },
 
     "importPaths": ["src"],


### PR DESCRIPTION
Make bindbc-wgpu working with DUB and any bindbc-loader 1.x.x so it will won't collide with other bindbc libraries